### PR TITLE
Release-0.2.8-2

### DIFF
--- a/vapi/toxav.vapi
+++ b/vapi/toxav.vapi
@@ -1,6 +1,43 @@
+
+/**
+ * == Public audio/video API for Tox clients. ==
+ *
+ * This API can handle multiple calls. Each call has its state, in very rare
+ * occasions the library can change the state of the call without apps knowledge.
+ *
+ *
+ * === Events and callbacks ===
+ *
+ * As in Core API, events are handled by callbacks. One callback can be
+ * registered per event. All events have a callback function type named
+ * `toxav_{event}_cb` and a function to register it named `toxav_callback_{event}`.
+ * Passing a NULL callback will result in no callback being registered for that
+ * event. Only one callback per event can be registered, so if a client needs
+ * multiple event listeners, it needs to implement the dispatch functionality
+ * itself. Unlike Core API, lack of some event handlers will cause the the
+ * library to drop calls before they are started. Hanging up call from a
+ * callback causes undefined behaviour.
+ *
+ * === Threading implications ===
+ *
+ * Unlike the Core API, this API is fully thread-safe. The library will ensure
+ * the proper synchronization of parallel calls.
+ *
+ * A common way to run ToxAV (multiple or single instance) is to have a thread,
+ * separate from tox instance thread, running a simple toxav_iterate loop,
+ * sleeping for toxav_iteration_interval * milliseconds on each iteration.
+ *
+ * An important thing to note is that events are triggered from both tox and
+ * toxav thread (see above). Audio and video receive frame events are triggered
+ * from toxav thread while all the other events are triggered from tox thread.
+ *
+ * Tox thread has priority with mutex mechanisms. Any api function can
+ * fail if mutexes are held by tox thread in which case they will set SYNC
+ * error code.
+ */
 [CCode(cheader_filename = "tox/toxav.h", cprefix = "")]
 namespace ToxAV {
-  [CCode(cname = "TOXAV_ERR_NEW", cprefix = "TOXAV_ERR_NEW_", has_type_id = false)]
+  [CCode(cname = "Toxav_Err_New", cprefix = "TOXAV_ERR_NEW_", has_type_id = false)]
   public enum ErrNew {
     /**
      * The function returned successfully.
@@ -21,7 +58,7 @@ namespace ToxAV {
     MULTIPLE
   }
 
-  [CCode(cname = "TOXAV_ERR_CALL", cprefix = "TOXAV_ERR_CALL_", has_type_id = false)]
+  [CCode(cname = "Toxav_Err_Call", cprefix = "TOXAV_ERR_CALL_", has_type_id = false)]
   public enum ErrCall {
     /**
      * The function returned successfully.
@@ -55,7 +92,7 @@ namespace ToxAV {
     INVALID_BIT_RATE
   }
 
-  [CCode(cname = "TOXAV_ERR_ANSWER", cprefix = "TOXAV_ERR_ANSWER_", has_type_id = false)]
+  [CCode(cname = "Toxav_Err_Answer", cprefix = "TOXAV_ERR_ANSWER_", has_type_id = false)]
   public enum ErrAnswer {
     /**
      * The function returned successfully.
@@ -124,7 +161,7 @@ namespace ToxAV {
     ACCEPTING_V
   }
 
-  [CCode(cname = "TOXAV_CALL_CONTROL", cprefix = "TOXAV_CALL_CONTROL_", has_type_id = false)]
+  [CCode(cname = "Toxav_Call_Control", cprefix = "TOXAV_CALL_CONTROL_", has_type_id = false)]
   public enum CallControl {
     /**
      * Resume a previously paused call. Only valid if the pause was caused by this
@@ -162,7 +199,7 @@ namespace ToxAV {
     SHOW_VIDEO
   }
 
-  [CCode(cname = "TOXAV_ERR_CALL_CONTROL", cprefix = "TOXAV_ERR_CALL_CONTROL_", has_type_id = false)]
+  [CCode(cname = "Toxav_Err_Call_Control", cprefix = "TOXAV_ERR_CALL_CONTROL_", has_type_id = false)]
   public enum ErrCallControl {
     /**
      * The function returned successfully.
@@ -188,7 +225,7 @@ namespace ToxAV {
     INVALID_TRANSITION
   }
 
-  [CCode(cname = "TOXAV_ERR_BIT_RATE_SET", cprefix = "TOXAV_ERR_BIT_RATE_SET_", has_type_id = false)]
+  [CCode(cname = "Toxav_Err_Bit_Rate_Set", cprefix = "TOXAV_ERR_BIT_RATE_SET_", has_type_id = false)]
   public enum ErrBitRateSet {
     /**
      * The function returned successfully.
@@ -212,7 +249,7 @@ namespace ToxAV {
     FRIEND_NOT_IN_CALL
   }
 
-  [CCode(cname = "TOXAV_ERR_SEND_FRAME", cprefix = "TOXAV_ERR_SEND_FRAME_", has_type_id = false)]
+  [CCode(cname = "Toxav_Err_Send_Frame", cprefix = "TOXAV_ERR_SEND_FRAME_", has_type_id = false)]
   public enum ErrSendFrame {
     /**
      * The function returned successfully.

--- a/vapi/toxencryptsave.vapi
+++ b/vapi/toxencryptsave.vapi
@@ -1,3 +1,54 @@
+/*
+ * Copyright © 2016-2018 The TokTok team.
+ * Copyright © 2013-2016 Tox Developers.
+ *
+ * This file is part of Tox, the free peer to peer instant messenger.
+ *
+ * Tox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This module is organized into two parts.
+ *
+ *  1. A simple API operating on plain text/cipher text data and a password to encrypt or decrypt it.
+ *  1. A more advanced API that splits key derivation and encryption into two separate function calls.
+ *
+ * The first part is implemented in terms of the second part and simply calls
+ * the separate functions in sequence. Since key derivation is very expensive
+ * compared to the actual encryption, clients that do a lot of crypto should
+ * prefer the advanced API and reuse pass-key objects.
+ *
+ * To use the second part, first derive an encryption key from a password with
+ * tox_pass_key_derive, then use the derived key to encrypt the data.
+ *
+ * The encrypted data is prepended with a magic number, to aid validity
+ * checking (no guarantees are made of course). Any data to be decrypted must
+ * start with the magic number.
+ *
+ * Clients should consider alerting their users that, unlike plain data, if
+ * even one bit becomes corrupted, the data will be entirely unrecoverable.
+ * Ditto if they forget their password, there is no way to recover the data.
+ *
+ * === Part 1 ===
+ *
+ * The simple API is presented first. If your code spends too much time using
+ * these functions, consider using the advanced functions instead and caching
+ * the generated pass-key.
+ *
+ *  * {@link pass_encrypt}
+ *  * {@link pass_decrypt}
+ */
 [CCode(cheader_filename = "tox/toxencryptsave.h", cprefix = "Tox", lower_case_cprefix = "tox_")]
 namespace ToxEncryptSave {
   /**
@@ -34,7 +85,7 @@ namespace ToxEncryptSave {
    */
   public uint32 pass_encryption_extra_length();
 
-  [CCode(cname = "TOX_ERR_KEY_DERIVATION", cprefix = "TOX_ERR_KEY_DERIVATION_")]
+  [CCode(cname = "TOX_ERR_KEY_DERIVATION", cprefix = "TOX_ERR_KEY_DERIVATION_", has_type_id = false)]
   public enum ErrKeyDerivation {
     /**
      * The function returned successfully.
@@ -51,7 +102,7 @@ namespace ToxEncryptSave {
     FAILED
   }
 
-  [CCode(cname = "TOX_ERR_ENCRYPTION", cprefix = "TOX_ERR_ENCRYPTION_")]
+  [CCode(cname = "TOX_ERR_ENCRYPTION", cprefix = "TOX_ERR_ENCRYPTION_", has_type_id = false)]
   public enum ErrEncryption {
     /**
      * The function returned successfully.
@@ -73,7 +124,7 @@ namespace ToxEncryptSave {
     FAILED
   }
 
-  [CCode(cname = "TOX_ERR_DECRYPTION", cprefix = "TOX_ERR_DECRYPTION_")]
+  [CCode(cname = "TOX_ERR_DECRYPTION", cprefix = "TOX_ERR_DECRYPTION_", has_type_id = false)]
   public enum ErrDecryption {
     /**
      * The function returned successfully.
@@ -236,7 +287,7 @@ namespace ToxEncryptSave {
     }
   }
 
-  [CCode(cname = "TOX_ERR_GET_SALT", cprefix = "TOX_ERR_GET_SALT_")]
+  [CCode(cname = "TOX_ERR_GET_SALT", cprefix = "TOX_ERR_GET_SALT_", has_type_id = false)]
   public enum ErrGetSalt {
     /**
      * The function returned successfully.


### PR DESCRIPTION
* Added missing documentation
* Added correct `[Version()]` tags
* Added deprecated functions for compatibility
* Fixed enums 